### PR TITLE
atualiza o vendor para vtex e corrige mensagens para "Pickup Point"

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "vendor": "chilemat",
+  "vendor": "vtex",
   "name": "pickup",
   "version": "0.0.1",
   "builders": {

--- a/react/PickupStore.jsx
+++ b/react/PickupStore.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { defineMessages } from "react-intl";
 import { useCssHandles } from "vtex.css-handles";
 import { Modal } from "./components/Modal";
@@ -53,8 +53,8 @@ const PickupStore = ({ isActive }) => {
 };
 
 const messages = defineMessages({
-  title: { defaultMessage: "Pickup Store" },
-  description: { defaultMessage: "Pickup Store" },
+  title: { defaultMessage: "Pickup Point" },
+  description: { defaultMessage: "Pickup Point" },
 });
 
 PickupStore.schema = {


### PR DESCRIPTION
This pull request updates the vendor information and improves the naming consistency for the pickup feature. The most notable changes include switching the vendor from `chilemat` to `vtex` and updating user-facing text to refer to "Pickup Point" instead of "Pickup Store".

**Vendor update:**
* Changed the `vendor` field in `manifest.json` from `chilemat` to `vtex`, aligning the package with the correct vendor.

**Naming consistency:**
* Updated the default messages for `title` and `description` in `PickupStore.jsx` to use "Pickup Point" instead of "Pickup Store", ensuring consistent terminology in the UI.

**Code cleanup:**
* Simplified the import statement in `PickupStore.jsx` by removing the unnecessary `React` default import, as only hooks are used.